### PR TITLE
Feature/encode report

### DIFF
--- a/tsip/base.py
+++ b/tsip/base.py
@@ -12,9 +12,10 @@ from tsip.constants import DLE, DLE_STRUCT, ETX, ETX_STRUCT
 
 def _extract_code_from_packet(packet):
     code = struct.unpack('>B', packet[0])[0]
-    if code in [0x8f, 0x8e]:
+    if code in [0x8E, 0x8F, 0xA0, 0xA5]:
         return struct.unpack('>H', packet[0:2])[0]
     return code
+
 
 def _extract_data_from_packet(packet):
     code = _extract_code_from_packet(packet)
@@ -25,85 +26,98 @@ def _extract_data_from_packet(packet):
 
 
 class Packet(object):
-    _format = ''
+    _code = None
+    _format = None
     _values = []
 
     def __getitem__(self, index):
         return self._values[index]
 
+    def __setitem__(self, i, v):
+        self._values[i] = v
 
-class Report(Packet):
+    def __len__(self):
+        return len(self._values)
 
-    def __init__(self, packet):
+    def set_packet(self, packet):
         # TODO: strip DLE, DLE+ETX if still present
         self._packet = packet
+        code = _extract_code_from_packet(packet)
+        if code != self._code:
+            raise ValueError('Packet code %X != Report code %X' %
+                             (code, self._code))
+
+        self._data = _extract_data_from_packet(packet)
+
+        if self._format and len(self._data) != self._format.size:
+            raise ValueError('ID %04X Got %d bytes, expected %d bytes for %s' %
+                             (self._code, len(self._data), self._format.size, self._format))
+
+        try:
+            self._values = list(self._format.unpack(self._data))
+        except AttributeError:
+            # assuming GPS data with extended tsip serial, crc at end
+            # need better way to deal with this
+            serial, crc = struct.unpack('<HI', self.data[-6:])
+
+            self._values = [ord(c) for c in self.data[0:-6]] + [serial, crc]
+
+    def set_values(self, values):
+        if len(values) != self._formatlen:
+            raise TypeError('%s takes exactly %d arguments (%d given)' %
+                            (self._format.format, self._formatlen, len(values)))
+        self._values = values
+        self._data = self._pack_values()
+        self._packet = self._pack_code() + self._data
 
     @property
     def code(self):
-        return _extract_code_from_packet(self._packet)
+        return self._code
 
-    
     @property
     def data(self):
-        return _extract_data_from_packet(self._packet)
-
+        return self._data
 
     @property
     def values(self):
-        return struct.unpack(self._format, self.data)
+        return self._values
 
+    def _pack_code(self):
+        if self._code > 255:
+            return struct.pack('>H', self._code)
+        else:
+            return struct.pack('>B', self._code)
 
-    def __getitem__(self, i):
-        return self.values[i]
+    def _pack_values(self):
+        return self._format.pack(*self._values)
 
-
-    def __len__(self):
-        return len(self.values)
-
+    @property
+    def packet(self):
+        return self._packet
 
     @property
     def _formatlen(self):
-        """
-        Number of fields in `self._format`.
+        """Number of fields in `self._format`."""
+        return len(filter(lambda i: i in 'cbB?hHiIlLqQfdspP', self._format.format))
 
-        """
 
-        return len(filter(lambda i: i in ['cbB?hHiIlLqQfdspP'], self._format))
-        
+class Report(Packet):
+
+    def __init__(self, packet=None, values=None):
+        if packet is not None:
+            self.set_packet(packet)
+        elif values is not None:
+            self.set_values(values)
+
+
 
 # TODO: make self._values a descriptor
 class Command(Packet):
-    _code = None
 
-    def __init__(self, *values):
-        values = list(values)
-
-        if len(values) != self._formatlen:
-            raise TypeError('takes exactly %d arguments (%d given)' % 
-                            (self._formatlen, len(values)))
-
-        self._values = list(values)
-
-
-    @property
-    def code(self):
-        # Make self.code read-only.
-        return self._code
-
-    def _pack_code(self):
-        if self.code > 255:
-            return struct.pack('>H', self.code)
-        else:
-            return struct.pack('>B', self.code)
-
-
-    def _pack_values(self):
-        return struct.pack(self._format, *self._values)
-        
-
-    @property
-    def _packet(self):
-       return self._pack_code() + self._pack_values()
-
-    def __setitem__(self, i, v):
-        self._values[i] = v
+    def __init__(self, *args, **kwargs):
+        if len(args):
+            self.set_values(args)
+        elif 'packet' in kwargs:
+            self.set_packet(kwargs['packet'])
+        elif 'values' in kwargs:
+            self.set_values(kwargs['values'])

--- a/tsip/gps.py
+++ b/tsip/gps.py
@@ -97,7 +97,8 @@ class GPS(object):
                         pass
                     elif (packet.count(DLE_STRUCT, 1) % 2) == 0:
                         # Number of DLE is even, not odd; keep reading...
-                        if __debug__: _LOG.debug('GPS.next: Number of DLE is even')
+                        if __debug__: _LOG.info('GPS.next: Number of DLE is even')
+                        raise ValueError('Bad framing, dropping %d bytes' % len(packet))
                         pass
                     else:
                         # Passed all checks, break out of the while True loop
@@ -116,6 +117,8 @@ class GPS(object):
 
 
             packet = packet + b
+            if len(packet) > 1000:
+                 raise ValueError('Packet too long, lost something? CMD 0x%02x 0x%02x' % (ord(packet[1]), ord(packet[2])))
             # end while True
 
 


### PR DESCRIPTION
Hello Markus,

Firstly, I don't expect you to actually pull this code! But it seems the easiest way to show it to you.

I embarked on some enhancement and refactoring, now I see you are making changes - I don't really want to diverge unnecessarily.

First commit:
about GPS error recovery:  I have a record from a GPS where data has been lost occasionally.  Without my changes here, the packet framing parser would run through a lot of data before (if ever) resynchronizing to a correct packet boundary.

Second commit:
I need to be able to emulate a GPS device. Hence need to be able to encode Report, decode Command.
Thus both Command and Report packets have basically the same functionality, and most has been moved into Packet base class.  
So, a Packet can be initialized either from packet data, or from a list of values.

Additionally, an idea for which I can't show full code yet (need to check if I can publish new packet formats)

Have each packetXX.py define its own code_report_map, and merge this into the master dictionary thus:

import packetsA0_A5
_code_report_map.update(packetsA0_A5.code_report_map)

This avoids having to import every packet class explicitly, and having to update packets.py when adding a packet def to another file.
