### PR TITLE
Fix off by one in for loop

### DIFF
--- a/tsip/structs.py
+++ b/tsip/structs.py
@@ -157,7 +157,7 @@ class Struct0x47(object):
         count = struct.unpack('>B', s[1])[0]
         fields = [0x47, count]
 
-        for i in range(0, count-1):
+        for i in range(0, count):
             i1 = 2 + i * 5
             i2 = 2 + i * 5 + 5
             (satnum, siglevel) = struct.unpack('>Bf', s[i1:i2])


### PR DESCRIPTION
Range end value is already non-inclusive. Using count-1 results in last SV not being reported.

Before change, only 7 SVs are reported, despite count=8:
```
Packet(71, 8, 17, -0.0, 31, -0.0, 7, -0.0, 2, -0.0, 15, -0.0, 22, -0.0, 4, -0.0)
```

After change, all 8 SVs are reported:
```
Packet(71, 8, 29, -0.0, 1, -0.0, 18, -0.0, 32, -0.0, 5, -0.0, 30, -0.0, 20, -0.0, 26, -0.0)
```