### PR TITLE
Replace '+' character with word "and"

### DIFF
--- a/tsip/hlapi.py
+++ b/tsip/hlapi.py
@@ -107,7 +107,7 @@ class Packet(object):
             raise PackError(self)
 
 
-        # Possible structs for packet ID + subcode
+        # Possible structs for packet ID and subcode
         #
         if structs_ == []:
             try:


### PR DESCRIPTION
Proposed simple fix for Issue #36 to eliminate utf-7 encoding error generated by unescaped '+' character.